### PR TITLE
Add basic UI templates and router

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,17 @@
+from pathlib import Path
+
 from fastapi import FastAPI
-from src.api import users_router, campaigns_router, tasks_router, rigs_router, wells_router, dashboard_router
+from fastapi.templating import Jinja2Templates
+
+from src.api import (
+    users_router,
+    campaigns_router,
+    tasks_router,
+    rigs_router,
+    wells_router,
+    dashboard_router,
+)
+from src.ui.routes import router as ui_router
 
 # For mock implementation, we don't need to create database tables
 # from src.database import engine, Base
@@ -11,6 +23,9 @@ app = FastAPI(
     version="1.0.0"
 )
 
+TEMPLATE_DIR = Path(__file__).resolve().parent / "ui" / "templates"
+templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
+
 # Include API routers
 app.include_router(users_router)
 app.include_router(campaigns_router)
@@ -18,6 +33,7 @@ app.include_router(tasks_router)
 app.include_router(rigs_router)
 app.include_router(wells_router)
 app.include_router(dashboard_router)
+app.include_router(ui_router, prefix="/ui")
 
 
 @app.get("/")

--- a/src/ui/routes.py
+++ b/src/ui/routes.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+router = APIRouter()
+
+
+def get_templates() -> Jinja2Templates:
+    from src.main import templates
+
+    return templates
+
+
+@router.get("/", response_class=HTMLResponse)
+async def ui_home(
+    request: Request, templates: Jinja2Templates = Depends(get_templates)
+):
+    return templates.TemplateResponse("home.html", {"request": request})
+
+
+@router.get("/about", response_class=HTMLResponse)
+async def ui_about(
+    request: Request, templates: Jinja2Templates = Depends(get_templates)
+):
+    return templates.TemplateResponse("about.html", {"request": request})

--- a/src/ui/templates/about.html
+++ b/src/ui/templates/about.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}About - DDash{% endblock %}
+
+{% block content %}
+<h1>About DDash</h1>
+<p>This is a placeholder page.</p>
+{% endblock %}

--- a/src/ui/templates/base.html
+++ b/src/ui/templates/base.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>{% block title %}DDash{% endblock %}</title>
+</head>
+<body>
+    <nav>
+        <a href="/ui/">Home</a>
+        <a href="/ui/about">About</a>
+    </nav>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/src/ui/templates/home.html
+++ b/src/ui/templates/home.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block title %}Home - DDash{% endblock %}
+
+{% block content %}
+<h1>Welcome to DDash</h1>
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold HTML base layout and UI templates
- configure FastAPI to use Jinja2 templates and include UI router
- add simple UI router serving home and about pages

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac140ab8508320b0c176d73065de4e